### PR TITLE
restored ENABLE_ASSERTS cmake flag

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,6 +4,8 @@
 #
 ################################################################################
 
+set(ENABLE_ASSERTS "ON" CACHE BOOL "to enable or disable assert checks for debug builds (mostly for developers).")
+
 
 add_library(hib
     assert.f90
@@ -78,6 +80,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
       PUBLIC
       # Non-specific options
       -std=legacy                               # Allow pre-Fortran 77 syntax (e.g. arbitrary length arrays)
+      -ffree-line-length-none                   # Allow arbitrary long lines. Needed as preprocessing could generate long line lengths.
       -fno-automatic                            # Put everything on the heap
       $<$<PLATFORM_ID:Linux>:-march=native>     # Tune generated code for host's micro-architecture
       $<$<PLATFORM_ID:Darwin>:-mtune=native>    # Tune generated code for host's micro-architecture (march not working on Darwin)
@@ -152,7 +155,11 @@ target_compile_definitions(hib PUBLIC _BUILD_DATE_="${TODAY}")
 target_compile_definitions(hib PUBLIC _HELPDIR_="${CMAKE_CURRENT_SOURCE_DIR}/doc/")
 # The following is to limit the max jtot number
 target_compile_definitions(hib PUBLIC MAX_NJTOT=1000)
-target_compile_definitions(hib PUBLIC DISABLE_HIB_ASSERT=1)
+target_compile_definitions(hib PUBLIC "$<$<CONFIG:Release>:DISABLE_HIB_ASSERT=1>")
+# asserts can be activated on non-release builds (eg debug build)
+if(NOT ENABLE_ASSERTS)
+  target_compile_definitions(hib PUBLIC "$<$<CONFIG:Debug>:DISABLE_HIB_ASSERT=1>")
+endif()
 
 
 # Link Blas and Lapack libraries

--- a/lib/bases/hiba02_2sg.F90
+++ b/lib/bases/hiba02_2sg.F90
@@ -1,3 +1,4 @@
+#include "assert.h"
 ! sy2sg (sav2sg/ptr2sg) defines, saves variables and reads          *
 !                  potential for doublet sigma scattering                *
 ! --------------------------------------------------------------------
@@ -822,6 +823,15 @@ irpot=1
 return
 !
 entry sav2sg (readpt)
+ASSERT(nrmax .eq. ispar(2))
+ASSERT(npar .eq. ispar(3))
+ASSERT(isym .eq. ispar(4))
+ASSERT(igu .eq. ispar(5))
+ASSERT(isa .eq. ispar(6))
+
+ASSERT(brot .eq. rspar(1))
+ASSERT(gsr .eq. rspar(2))
+
 !  save input parameters for doublet-sigma + atom scattering
 !  line 13:
 write (8, 220) nrmax, npar, isym, igu, isa

--- a/lib/bases/hiba24_sphtp.F90
+++ b/lib/bases/hiba24_sphtp.F90
@@ -1,3 +1,4 @@
+#include "assert.h"
 ! sysphtp (savsphtp/ptrsphtp) defines, saves variables and reads         *
 !                  potentials for spherical top + atom                   *
 ! ----------------------------------------------------------------------
@@ -1118,6 +1119,8 @@ irpot=1
 return
 ! --------------------------------------------------------------
 entry savsphtp (readp)
+ASSERT(iop .eq. ispar(2))
+ASSERT(jmax .eq. ispar(3))
 !  save input parameters for spherical top + atom scattering
 write (8, 310) iop, jmax
 310 format(2i4,25x,'iop, jmax')


### PR DESCRIPTION
users can now enable asserts in builds using the ENABLE_ASSERTS, which will activate all asserts

fixes issue #80