### PR TITLE
Allocate work arrays dynamically as max(1000,nmax)

### DIFF
--- a/lib/bases/hiba30_astp3.F90
+++ b/lib/bases/hiba30_astp3.F90
@@ -193,11 +193,11 @@ allocate(vec(narray,narray))
 allocate(sc1(narray))
 allocate(sc2(narray))
 
-allocate(work(min(1000,nmax)))
-allocate(kp(min(1000,nmax)))
-allocate(ko(min(1000,nmax)))
-allocate(j2rot(min(1000,nmax)))
-allocate(e2rot(min(1000,nmax)))
+allocate(work(max(1000,nmax)))
+allocate(kp(max(1000,nmax)))
+allocate(ko(max(1000,nmax)))
+allocate(j2rot(max(1000,nmax)))
+allocate(e2rot(max(1000,nmax)))
 
 zero = 0.d0
 two = 2.d0


### PR DESCRIPTION
Fixes issue #87 where segmentation faults were thrown for large basis set for basis 30.

Some of the work arrays for this basis were of size 1000, hardcoded.
This size isn't enough in some cases. 

Now those arrays are dynamically allocated with a size value of max(1000,nmax).