### PR TITLE
fixed silly error in `basis_get_isa`

### DIFF
--- a/lib/bases/hiba01_1sg.F90
+++ b/lib/bases/hiba01_1sg.F90
@@ -1150,7 +1150,7 @@ contains
   end if
   end function
 
-  logical function basis_get_isa(ibasty, ispar)
+  integer function basis_get_isa(ibasty, ispar)
   !     ------------------------------------------------------------------
   !
   !     returns the value of the isa parameter if the base has an isa parameter. returns zero otherwise


### PR DESCRIPTION
I was accidentally casting an integer into a logical then back to an integer. This produced different results in gfortran and ifort. The compiler probably issued a warning, but there are currently too many warnings that hide the important ones...

bug introduced while fixing issue #90
fixes issue #95