### PR TITLE
now the profiling mode handles multiple tests in the same directory :…

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,4 +193,4 @@ Then, `make html_coverages`, will convert these coverage files into html reports
 
 ### Performance profiling
 
-To activate profiling, add `-DENABLE_PROFILING=ON` to the cmake command. This will build and run hibridon with profiling option. When run, each test will additionnaly create a `call_graph.pdf` file which shows where time was spent during the test.
+To activate profiling, add `-DENABLE_PROFILING=ON` to the cmake command. This will build and run hibridon with profiling option. When run, each test will additionnaly create a `<test_id>_call_graph.pdf` file which shows where time was spent during the test.

--- a/cmake/modules/add_hibridon_test.cmake
+++ b/cmake/modules/add_hibridon_test.cmake
@@ -42,7 +42,7 @@ function(add_hibridon_test TEST_ID TEST_POT_SRC_FILE TEST_POT_DATA_FILES TEST_CO
 
   if(GENERATE_PROFILING_PDF)
     add_test(NAME ${TEST_ID}_build_profiling_pdf
-      COMMAND  bash -c "${PROFILING_GPROF_EXE} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_EXE}  | ${PROFILING_GPROF2DOT_EXE} | ${PROFILING_DOT_EXE} -Tpdf -o call_graph.pdf"
+      COMMAND  bash -c "${PROFILING_GPROF_EXE} ${CMAKE_CURRENT_BINARY_DIR}/${TEST_EXE} > ${TEST_ID}_gprofout.txt && cat ${TEST_ID}_gprofout.txt | ${PROFILING_GPROF2DOT_EXE} | ${PROFILING_DOT_EXE} -Tpdf -o ${TEST_ID}_call_graph.pdf"
       WORKING_DIRECTORY "${TEST_BUILD_DIR}")
     set_property(TEST ${TEST_ID}_build_profiling_pdf PROPERTY LABELS ${TEST_ID} ${TEST_LABELS})
   endif()


### PR DESCRIPTION
… the call graphs file names are now `<test_id>_call_graph.pdf` instead of `call_graph.pdf`

The profiling mode now also generates `<test_id>_gprofout.txt`, which provides a more complete report than just the call graph.

partially fixes #116