### PR TITLE
increased size of mod_cotq2::dpsii array because it was too small

### DIFF
--- a/lib/himem.F90
+++ b/lib/himem.F90
@@ -506,7 +506,7 @@ module mod_cotq2
    subroutine allocate_cotq2(n)
       integer, intent(in) :: n
       allocate(tq2(n,n))
-      allocate(dpsii(n))  ! note : the size has been found by trial and error (with all tests passing)
+      allocate(dpsii(n*n))  ! note : the size has been found by trial and error (with all tests passing)
       allocate(scmat(n*n))  ! note : the size has been found by trial and error (with all tests passing)
    end subroutine allocate_cotq2
 end module mod_cotq2


### PR DESCRIPTION
Note that the new size is more an educated guess than a scientific discovery... it would be nice to ensure that its size is the optimal one.

fixes issue #149