### PR TITLE
fixed integer overflow operation in iwavsk

### DIFF
--- a/lib/hibrid4.F90
+++ b/lib/hibrid4.F90
@@ -988,9 +988,9 @@ integer int_t
 double precision dble_t
 character char_t
 
-integer :: lr1  ! length of record 1 in bytes
-integer :: lrlogd  ! length of a logd record
-integer :: lrairy  ! length of an airy record
+integer(8) :: lr1  ! length of record 1 in bytes
+integer(8) :: lrlogd  ! length of a logd record
+integer(8) :: lrairy  ! length of an airy record
 integer, parameter :: char_size = int(sizeof(char_t), kind(int_t))
 integer, parameter :: int_size = int(sizeof(int_t), kind(int_t))
 integer, parameter :: dbl_size = int(sizeof(dble_t), kind(int_t))
@@ -1031,6 +1031,7 @@ end if
 write (0, *) '*** OOPS! ERROR SEEKING WFU FILE. ABORT.'
 call exit()
 100 continue
+ASSERT(iwavsk > 0)
 end
 !
 ! -------------------------------------------------------------------------
@@ -2994,6 +2995,7 @@ character*40 :: wavfil, eadfil
 common /coered/ ered, rmu
 real(8) :: ered
 real(8) :: rmu
+integer(8) :: seek_pos
 !
 double precision :: dble_t
 integer, parameter :: eadfil_unit = FUNIT_EADIAB
@@ -3028,8 +3030,9 @@ write(eadfil_unit, 17) nchmin, nchmax
 17 format (' ** ADIABATIC ENERGIES FROM NO.', i5, ' TO NO.', &
      i5, ' REQUESTED')
 do i = 4 + nrlogd, npts + 3
-   read (ifil, end=900, err=950, pos=iwavsk(i)) r, drnow
-   read (ifil, end=900, err=950, pos=iwavsk(i)+noffst) &
+   seek_pos = iwavsk(i)
+   read (ifil, end=900, err=950, pos=seek_pos) r, drnow
+   read (ifil, end=900, err=950, pos=seek_pos+noffst) &
         (sc8(j), j=1, nchpr)
    write(eadfil_unit, 20) -r + 0.5 * drnow
 20    format (f10.5, 1x, $)

--- a/lib/hiwav.F90
+++ b/lib/hiwav.F90
@@ -14,7 +14,7 @@ module mod_wave  ! mod_wav is a modern replacement of common block cowave
   contains
 function get_wfu_rec1_length(nchwfu)
   integer, intent(in) :: nchwfu  ! number of channels in wfu file
-  integer :: get_wfu_rec1_length
+  integer(8) :: get_wfu_rec1_length
   !     The three variables below are used to determine the (machine
   !     dependent) size of the built-in types
   character :: char_t


### PR DESCRIPTION
despite `iwavsk` function being declared as integer(8), the computations is contained were still using 4 bytes integer instead of 8 byte integers. This caused `iwavsk` result to be negative (`lrairy` was about 39mb (39513784) and with `irecr` = 59,  seek position exceeded the maximum positive value of a 4-byte integer, resulting in a negative value -2141459559)

Now the computations are performed using 8-byte integer arithmetics

fixes issue #110