### PR TITLE
forced the allocation of big local 2d arrays on the heap

### DIFF
--- a/lib/hibrid1.F90
+++ b/lib/hibrid1.F90
@@ -1386,10 +1386,10 @@ data powr /3.d0/
 !     dependent) built-in types
 double precision dble_t
 character char_t
-real(8) :: w(nch*nmax)
-real(8), dimension(nch*nmax) :: tmat
-real(8), dimension(nch*nmax) :: vecnow
-real(8), dimension(nch*nmax) :: vecnew
+real(8), allocatable :: w(:)
+real(8), allocatable :: tmat(:)
+real(8), allocatable :: vecnow(:)
+real(8), allocatable :: vecnew(:)
 !  vectors dimensioned nch
 real(8), dimension(nch) :: eigold
 real(8), dimension(nch) :: eignow
@@ -1402,6 +1402,10 @@ real(8), dimension(nch) :: gam1
 real(8), dimension(nch) :: gam2
 integer(8) :: lrairy ! length of an airy record in bytes
 ! ----------------------------------------------------------------------------
+allocate(w(nch*nmax))
+allocate(tmat(nch*nmax))
+allocate(vecnow(nch*nmax))
+allocate(vecnew(nch*nmax))
 if (.not.twoen) itwo = -1
 if (itwo .le. 0) then
   if (photof) then
@@ -1801,6 +1805,11 @@ if (.not. noprin) then
           '   RINCR =',f7.3, &
           '   DRMIN =',f7.3, '   DRMAX =',f7.3,'   NSTEP =', i4)
 end if
+
+deallocate(w)
+deallocate(tmat)
+deallocate(vecnow)
+deallocate(vecnew)
 
 return
 !

--- a/lib/hibrid3.F90
+++ b/lib/hibrid3.F90
@@ -529,7 +529,7 @@ real(8),allocatable :: bmat(:)
 
 !     w             scratch array of dimension (nmax,nch)
 !                   used as workspace for the potential matrix
-real(8) :: w(nmax*nch)
+real(8), allocatable :: w(:)
 
 !     The following variables are for size-determination of (machine
 !     dependent) built-in types
@@ -562,6 +562,7 @@ if (nsteps .ne. 0) then
    end if 
 end if
 
+allocate(w(nmax*nch))
 !     row, column and diagonal increments for matrices z and w
 nrow = 1
 ncol = nmax
@@ -983,6 +984,7 @@ if (nsteps /= 0) then
   !     propagation loop ends here
   250 continue
 
+  deallocate(w)
   deallocate(bmat)
   deallocate(amat)
 
@@ -2182,7 +2184,7 @@ logical, intent(in) :: kwrit
 logical, intent(in) :: ipos
 
 
-real(8) :: amat(nmax,nmax)
+real(8), allocatable :: amat(:,:)
 integer :: isc1(nch)
 
 data izero /0/
@@ -2212,6 +2214,8 @@ do   50  i = 1, nch
     lq(nopen) = lq(i)
   end if
 50 continue
+
+allocate(amat(nmax, nmax))
 if (nopen .lt. nch) then
 !  now pack the log-derivative matrix into a matrix of size nopen x nopen
 !  keeping only the open-channel components
@@ -2279,6 +2283,7 @@ if (wavefn) then
    iendwv = iendwv + 8 * sizeof(char_t) &
         + (4 * nopen ** 2 + nopen) * sizeof(dble_t)
 endif
+deallocate(amat)
 call mtime(t11,t22)
 ts=t11 - t1
 tsw=t22 -t2

--- a/lib/hibrid5.F90
+++ b/lib/hibrid5.F90
@@ -155,8 +155,8 @@ integer, intent(in) :: jlpold ! old value of parity, used to insure correct accu
 logical ipos, csflag, prsmat, prt2, writs, wrpart, prpart, &
         wrxsec, prxsec, flaghf, t2test, firstj, twomol, &
         nucros, faux, twojlp
-integer :: jpack(nmax*nmax)
-integer :: lpack(nmax*nmax)
+integer, allocatable :: jpack(:)
+integer, allocatable :: lpack(:)
 
 character*20 cdate
 integer :: soutpt_sc_file = 1
@@ -252,8 +252,12 @@ if (writs .and. nopen .gt. 0) then
                 jtotd, numin, numax, nud, nlevel, nlevop, nnout, &
                 jlev, inlev, elev, jout)
     end if
+    allocate(jpack(nmax*nmax))
+    allocate(lpack(nmax*nmax))
     call swrite (sr, si, jtot, jlpar, nu, jq, lq, inq, isc1, &
                  isc2, jpack, lpack, sc2, nfile, nmax, nopen)
+    deallocate(jpack)
+    deallocate(lpack)
 end if
 
 if (.not. prxsec .and. .not. wrxsec .and. .not.prpart &


### PR DESCRIPTION
These 2d arrays are too big for the stack (kmax * kmax) and they can cause stack overflows (that cause ugly segmentation error crashes) on some platforms.

fixes #189