### PR TITLE
Put back code coverage option to produce GCNOs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose Release or Debug" FORCE)
 endif()
 
+# Code coverage
+set(ENABLE_CODE_COVERAGE "OFF" CACHE BOOL "to enable or disable code coverage (mostly for developers)")
+
 # profiling is disabled by default because:
 # 1. most users won't need it: this is targetted to developers, not users
 # 2. it makes code slower

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -134,7 +134,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
       $<$<AND:$<BOOL:${ENABLE_UNINIT_VAR_RUNTIME_DETECTOR}>,$<CONFIG:DEBUG>>:-ffpe-trap=invalid,zero,overflow>
 
 
-      $<$<BOOL:${ENABLE_CODE_COVERAGE}>:--coverage> # Code coverage (same as -fprofile-arcs -ftest-coverage at compile time)
+      $<$<BOOL:${ENABLE_CODE_COVERAGE}>:--coverage -Wno-coverage-invalid-line-number> # Code coverage (same as -fprofile-arcs -ftest-coverage at compile time)
       $<$<BOOL:${ENABLE_PROFILING}>:-g>         # The profiler requires both the debug and profile directives (-g and -p)
       $<$<BOOL:${ENABLE_PROFILING}>:-p>         # The profiler requires both the debug and profile directives (-g and -p)
     )


### PR DESCRIPTION
setting the ENABLE_CODE_COVERAGE to 1 when configuring a project with the cmake command will enable code coverage compilation options with GCC.

.gcno files are generated in the same directory as the object files.
The percentage of code covered after an execution can be obtained using:
```
gcov <build_dir>/lib/CMakeFiles/hib.dir/**/*.gcno
```
where <build_dir> is the build directory.

