### PR TITLE
Basis30 with jmax more than 9

### DIFF
--- a/lib/bases/hiba30_astp3.F90
+++ b/lib/bases/hiba30_astp3.F90
@@ -711,8 +711,8 @@ if (bastst) then
     '   #  J1  IS  J2  J12  L     EINT(CM-1)'/1x,50('-'))
   do 330  i = 1, n
     ecm = eint(i) * econv
-    j1 = bqs%jq(i)/10
-    j2 = mod(bqs%jq(i),10)
+    j1 = bqs%jq(i)/100
+    j2 = mod(bqs%jq(i),100)
     if (bastst) then
       isize = isiz(i)
       isub = (i - 1)*narray
@@ -759,13 +759,13 @@ do 400 ilam = 1, nlam
   inum = 0
   ancouma => v2%get_angular_coupling_matrix(ilam)
   do 355 icol = 1, n
-    j1c = bqs%jq(icol)/10
-    j2c = mod(bqs%jq(icol),10)
+    j1c = bqs%jq(icol)/100
+    j2c = mod(bqs%jq(icol),100)
     j12c = bqs%j12(icol)
     lc = bqs%lq(icol)
     do 350 irow = icol, n
-      j1r = bqs%jq(irow)/10
-      j2r = mod(bqs%jq(irow),10)
+      j1r = bqs%jq(irow)/100
+      j2r = mod(bqs%jq(irow),100)
       j12r = bqs%j12(irow)
       lr = bqs%lq(irow)
       call vastp3(j1r,j2r,j12r,lr,j1c,j2c,j12c,lc, &

--- a/lib/bases/hiba30_astp3.F90
+++ b/lib/bases/hiba30_astp3.F90
@@ -543,7 +543,7 @@ do i2 = 1, i2num
 !
     nlevel = nlevel + 1
     ehold(nlevel) = (etemp(i1) + e2rot(i2)) / econv
-    jhold(nlevel) = 10 * ji + j2rot(i2)
+    jhold(nlevel) = 100 * ji + j2rot(i2)
     ishold(nlevel) = isi * ki
     kp(nlevel) = kp1
     ko(nlevel) = ko1
@@ -617,8 +617,8 @@ if (bastst) then
     '   #  J1  IS  KP  KO  J2  Eint(cm-1)  Coeffs'/1x,65('-'))
   do i = 1, nlevel
     ecm = ehold(i) * econv
-    j1 = jhold(i)/10
-    j2 = mod(jhold(i),10)
+    j1 = jhold(i)/100
+    j2 = mod(jhold(i),100)
     write (6, 135) i, j1, ishold(i), kp(i), ko(i), j2, ecm, &
       (chold(nn),nn=(i - 1)*narray + 1, &
       (i - 1)*narray + isizh(i))
@@ -643,8 +643,8 @@ do 250  i = 1, nlevel
 call bqs%init(nmax)
 n = 0
 do i = 1, nlevel
-  j1 = jhold(i)/10
-  j2 = mod(jhold(i),10)
+  j1 = jhold(i)/100
+  j2 = mod(jhold(i),100)
   ki = abs(ishold(i))
   iss = sign(1, ishold(i))
   ipar = iss * (-1) ** (j1 + j2 + ki)


### PR DESCRIPTION
Channels list was wrong when using JMAX values above 9.

This is because j1 was stored as `jhold/10` and j2 as `mod(jhold,10)`.

Changed the factor to 100 to allow j1 and j2 values greater than 9.